### PR TITLE
canAccess return of false should generate forbidden Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,7 +343,7 @@ module.exports.can = function can(operation, params, errorCallback) {
 
     $promise.then(data => req.session.can(operation, data))
       .then(accessGranted => {
-        if(accessGranted) {
+        if(!accessGranted) {
           return Promise.reject(new Error('forbidden'));
         }
         next();


### PR DESCRIPTION
When using easy-session and easy-rbac together in expressjs middleware. getting denied when should be granted and vise-versa.